### PR TITLE
Fix icon not properly defined

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
   },
 
   "license": "CC0-1.0",
-  "icon": "",
+  "icon": "assets/icon.png",
 
   "environment": "*",
   "entrypoints": {


### PR DESCRIPTION
The icon field was left blank, which resulted in Mod Menu complaining about it not having an icon, despite the icon already being included. This pull request fixes that.