### PR TITLE
Add german translation file

### DIFF
--- a/src/main/resources/assets/autoreconnect/lang/de_de.json
+++ b/src/main/resources/assets/autoreconnect/lang/de_de.json
@@ -1,0 +1,26 @@
+{
+  "text.autoreconnect.disconnect.reconnect": "Erneut verbinden",
+  "text.autoreconnect.disconnect.reconnect_in": "Verbinde erneut in %d...",
+  "text.autoreconnect.disconnect.cancel": "Abbrechen",
+  "text.autoreconnect.disconnect.reconnect_failed": "Verbindung konnte nicht wiederhergestellt werden!",
+
+  "text.autoreconnect.config.title": "AutoReconnect Konfiguration",
+  "text.autoreconnect.config.option.delays": "Verzögerungen",
+  "text.autoreconnect.config.option.infinite": "Unendlich",
+  "text.autoreconnect.config.option.automessages": "Automatische Nachrichten",
+  "text.autoreconnect.config.option.automessages.instance": "Automatische Nachricht",
+  "text.autoreconnect.config.option.automessages.name": "Bezeichnung",
+  "text.autoreconnect.config.option.automessages.messages": "Nachricht",
+  "text.autoreconnect.config.option.automessages.delay": "Verzögerung",
+
+  "text.autoreconnect.config.tooltip.option.delays": "Verzögerungen zwischen den\nVerbindungsversuchen in Sekunden.",
+  "text.autoreconnect.config.tooltip.option.infinite": "Ob unbegrenzt oft versucht werden\nsoll die Verbindung mit der letzten\nVerzögerung wiederherzustellen.",
+  "text.autoreconnect.config.tooltip.option.automessages": "Nachrichten automatisch nach\ndem erneuten Verbinden senden.",
+  "text.autoreconnect.config.tooltip.option.automessages.instance": "Einzelne automatische Nachricht\nfür eine spezifische Welt, Server\noder einen Realm.",
+  "text.autoreconnect.config.tooltip.option.automessages.name": "Name der Einzelspielerwelt,\ndes Servers oder des Realms.",
+  "text.autoreconnect.config.tooltip.option.automessages.messages": "Nachricht, die nach einer erneuten\nVerbindung gesendet werden soll.",
+  "text.autoreconnect.config.tooltip.option.automessages.delay": "Verzögerung vor der ersten und\nzwischen jeder weiteren Nachricht.",
+
+  "text.autoreconnect.config.error.empty_list": "Leere Liste!",
+  "text.autoreconnect.config.error.empty_string": "Leeres Textfeld!"
+}

--- a/src/main/resources/assets/autoreconnect/lang/de_de.json
+++ b/src/main/resources/assets/autoreconnect/lang/de_de.json
@@ -19,7 +19,7 @@
   "text.autoreconnect.config.tooltip.option.automessages.instance": "Einzelne automatische Nachricht\nfür eine spezifische Welt, Server\noder einen Realm.",
   "text.autoreconnect.config.tooltip.option.automessages.name": "Name der Einzelspielerwelt,\ndes Servers oder des Realms.",
   "text.autoreconnect.config.tooltip.option.automessages.messages": "Nachricht, die nach einer erneuten\nVerbindung gesendet werden soll.",
-  "text.autoreconnect.config.tooltip.option.automessages.delay": "Verzögerung vor der ersten und\nzwischen jeder weiteren Nachricht.",
+  "text.autoreconnect.config.tooltip.option.automessages.delay": "Verzögerung vor der ersten und\nzwischen jeder weiteren Nachricht\nin Millisekunden.",
 
   "text.autoreconnect.config.error.empty_list": "Leere Liste!",
   "text.autoreconnect.config.error.empty_string": "Leeres Textfeld!"

--- a/src/main/resources/assets/autoreconnect/lang/de_de.json
+++ b/src/main/resources/assets/autoreconnect/lang/de_de.json
@@ -2,7 +2,7 @@
   "text.autoreconnect.disconnect.reconnect": "Erneut verbinden",
   "text.autoreconnect.disconnect.reconnect_in": "Verbinde erneut in %d...",
   "text.autoreconnect.disconnect.cancel": "Abbrechen",
-  "text.autoreconnect.disconnect.reconnect_failed": "Verbindung konnte nicht wiederhergestellt werden!",
+  "text.autoreconnect.disconnect.reconnect_failed": "Konnte nicht erneut verbinden!",
 
   "text.autoreconnect.config.title": "AutoReconnect Konfiguration",
   "text.autoreconnect.config.option.delays": "Verzögerungen",


### PR DESCRIPTION
I've added a german translation for this mod. As the german sentences are a little bit longer, I also added linebreaks with `\n` which works without an issue, as the tooltips won't wrap on their own when the screen is too small.