### PR TITLE
Update the mod to 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.5
-loader_version=0.14.12
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.19
 
 # Mod Properties
 mod_id = autoreconnect
 mod_name = AutoReconnect
-mod_version = 2.1.0-beta
+mod_version = 3.0.0-beta
 archives_base_name = autoreconnect
 
 # Dependencies
-fabric_version=0.73.2+1.19.3
-modmenu_version=5.0.0
-cloth_config_version=9.0.94
+fabric_version=0.76.0+1.19.4
+modmenu_version=6.1.0-rc.4
+cloth_config_version=10.0.96

--- a/remappedSrc/autoreconnect/AutoReconnect.java
+++ b/remappedSrc/autoreconnect/AutoReconnect.java
@@ -1,0 +1,185 @@
+package autoreconnect;
+
+import autoreconnect.config.AutoReconnectConfig;
+import autoreconnect.reconnect.ReconnectStrategy;
+import autoreconnect.reconnect.SingleplayerReconnectStrategy;
+import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.DisconnectedScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.gui.screen.world.SelectWorldScreen;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.realms.gui.screen.RealmsMainScreen;
+
+import java.util.Iterator;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntConsumer;
+
+public class AutoReconnect implements ClientModInitializer {
+    private static final ScheduledThreadPoolExecutor EXECUTOR_SERVICE = new ScheduledThreadPoolExecutor(1);
+    private static AutoReconnect instance;
+    private final AtomicReference<ScheduledFuture<?>> countdown = new AtomicReference<>(null);
+    private ReconnectStrategy reconnectStrategy = null;
+
+    static {
+        EXECUTOR_SERVICE.setRemoveOnCancelPolicy(true);
+    }
+
+    @Override
+    public void onInitializeClient() {
+        instance = this;
+        AutoReconnectConfig.load();
+    }
+
+    public static AutoReconnect getInstance() {
+        return instance;
+    }
+
+    public static AutoReconnectConfig getConfig() {
+        return AutoReconnectConfig.getInstance();
+    }
+
+    public static void schedule(Runnable command, long delay, TimeUnit timeUnit) {
+        EXECUTOR_SERVICE.schedule(command, delay, timeUnit);
+    }
+
+    public void setReconnectHandler(ReconnectStrategy reconnectStrategy) {
+        if (this.reconnectStrategy != null) {
+            // should imply that both handlers target the same world/server
+            // we return to preserve the attempts counter
+            assert this.reconnectStrategy.getClass().equals(reconnectStrategy.getClass()) &&
+                    this.reconnectStrategy.getName().equals(reconnectStrategy.getName());
+            return;
+        }
+        this.reconnectStrategy = reconnectStrategy;
+    }
+
+    public void reconnect() {
+        if (reconnectStrategy == null) return; // shouldn't happen normally, but can be forced
+        cancelCountdown();
+        reconnectStrategy.reconnect();
+    }
+
+    public void startCountdown(final IntConsumer callback) {
+        // if (countdown.get() != null) return; // should not happen
+        int delay = getConfig().getDelayForAttempt(reconnectStrategy.nextAttempt());
+        if (delay >= 0) {
+            countdown(delay, callback);
+        } else {
+            // no more attempts configured
+            callback.accept(-1);
+        }
+    }
+
+    public void cancelAutoReconnect() {
+        if (reconnectStrategy == null) return; // should not happen
+        reconnectStrategy.resetAttempts();
+        cancelCountdown();
+    }
+
+    public void onScreenChanged(Screen current, Screen next) {
+        if (sameType(current, next)) return;
+        // TODO condition could use some improvement, shouldn't cause any issues tho
+        if (!isMainScreen(current) && isMainScreen(next) || isReAuthenticating(current, next)) {
+            cancelAutoReconnect();
+            reconnectStrategy = null;
+        }
+    }
+
+    public void onGameJoined() {
+        if (reconnectStrategy == null) return; // should not happen
+        if (!reconnectStrategy.isAttempting()) return; // manual (re)connect
+
+        reconnectStrategy.resetAttempts();
+
+        // Send automatic messages if configured for the current context
+        getConfig().getAutoMessagesForName(reconnectStrategy.getName()).ifPresent(
+                autoMessages -> sendAutomatedMessages(
+                        MinecraftClient.getInstance().player,
+                        autoMessages.getMessages(),
+                        autoMessages.getDelay()
+                )
+        );
+    }
+
+    public boolean isPlayingSingleplayer() {
+        return reconnectStrategy instanceof SingleplayerReconnectStrategy;
+    }
+
+    private void cancelCountdown() {
+        synchronized (countdown) { // just to be sure
+            if (countdown.get() == null) return;
+            countdown.getAndSet(null).cancel(true); // should stop the timer
+        }
+    }
+
+    // simulated timer using delayed recursion
+    private void countdown(int seconds, final IntConsumer callback) {
+        if (reconnectStrategy == null) return; // should not happen
+        if (seconds == 0) {
+            MinecraftClient.getInstance().execute(this::reconnect);
+            return;
+        }
+        callback.accept(seconds);
+        // wait at end of method for no initial delay
+        synchronized (countdown) { // just to be sure
+            countdown.set(EXECUTOR_SERVICE.schedule(() ->
+                    countdown(seconds - 1, callback), 1, TimeUnit.SECONDS));
+        }
+    }
+
+    /**
+     * Handle a list of messages to send by the player to the current connection.
+     *
+     * @param player   Player to send the message as.
+     * @param messages String Iterator of messages to send.
+     * @param delay    Delay in milliseconds before the first and between each following message.
+     */
+    private void sendAutomatedMessages(ClientPlayerEntity player, Iterator<String> messages, int delay) {
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService.scheduleWithFixedDelay(() -> {
+            if (!messages.hasNext()) {
+                executorService.shutdown();
+                return;
+            }
+
+            sendMessage(player, messages.next());
+        }, delay, delay, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Handles sending of a single message or command by the player.
+     *
+     * @param player  Player to send the message as.
+     * @param message String with the message or command to send.
+     */
+    private void sendMessage(ClientPlayerEntity player, String message) {
+        if (message.startsWith("/")) {
+            // The first starting slash has to be removed,
+            // otherwise it will be interpreted as a double slash.
+            String command = message.substring(1);
+            player.networkHandler.sendCommand(command);
+        } else {
+            player.networkHandler.sendChatMessage(message);
+        }
+    }
+
+    private static boolean sameType(Object a, Object b) {
+        if (a == null && b == null) return true;
+        if (a != null && b != null) return a.getClass().equals(b.getClass());
+        return false;
+    }
+
+    private static boolean isMainScreen(Screen screen) {
+        return screen instanceof TitleScreen || screen instanceof SelectWorldScreen ||
+                screen instanceof MultiplayerScreen || screen instanceof RealmsMainScreen;
+    }
+
+    private static boolean isReAuthenticating(Screen from, Screen to) {
+        return from instanceof DisconnectedScreen && to != null &&
+                to.getClass().getName().startsWith("me.axieum.mcmod.authme");
+    }
+}

--- a/remappedSrc/autoreconnect/config/AutoReconnectConfig.java
+++ b/remappedSrc/autoreconnect/config/AutoReconnectConfig.java
@@ -1,0 +1,100 @@
+package autoreconnect.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import net.fabricmc.loader.api.FabricLoader;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class AutoReconnectConfig {
+    private static final String FILE_NAME = "autoreconnect.json";
+    private static final Gson GSON = new GsonBuilder().setLenient().setPrettyPrinting().create();
+    private static AutoReconnectConfig instance;
+
+    static final List<Integer> defaultDelays = List.of(3, 10, 30, 60);
+    static final int defaultDelay = 10;
+    static final boolean defaultInfinite = false;
+    static final List<AutoMessages> defaultAutoMessages = List.of();
+
+    List<Integer> delays = defaultDelays;
+    boolean infinite = defaultInfinite;
+    List<AutoMessages> autoMessages = defaultAutoMessages;
+
+    private AutoReconnectConfig() { }
+
+    public static AutoReconnectConfig getInstance() {
+        return instance;
+    }
+
+    public static void load() {
+        try {
+            instance = GSON.fromJson(
+                Files.readString(FabricLoader.getInstance().getConfigDir().resolve(FILE_NAME)),
+                AutoReconnectConfig.class);
+            instance.validate();
+        } catch (IOException | JsonSyntaxException ex) {
+            LogManager.getRootLogger().warn("AutoReconnect could not load the config", ex);
+            instance = new AutoReconnectConfig();
+        }
+    }
+
+    private void validate() {
+        if (delays == null) delays = defaultDelays;
+        else if (!delays.isEmpty()) delays = delays.stream().filter(i -> i > 0).toList();
+        if (autoMessages == null) autoMessages = defaultAutoMessages;
+        else if (!autoMessages.isEmpty()) for (AutoMessages autoMessage : autoMessages) {
+            if (autoMessage.name == null) autoMessage.name = AutoMessages.defaultName;
+            if (autoMessage.messages == null) autoMessage.messages = AutoMessages.defaultMessages;
+            else if (!autoMessage.messages.isEmpty())
+                autoMessage.messages = autoMessage.messages.stream().filter(Objects::nonNull).toList();
+            if (autoMessage.delay <= 0) autoMessage.delay = AutoMessages.defaultDelay;
+        }
+    }
+
+    public void save() {
+        try {
+            Files.writeString(FabricLoader.getInstance().getConfigDir().resolve(FILE_NAME), GSON.toJson(this));
+        } catch (IOException ex) {
+            LogManager.getRootLogger().warn("AutoReconnect could not load the config", ex);
+        }
+    }
+
+    public int getDelayForAttempt(int attempt) {
+        if (attempt < delays.size()) return delays.get(attempt);
+        if (infinite) return delays.get(delays.size() - 1); // repeat last
+        return -1; // no more attempts configured
+    }
+
+    public boolean hasAttempts() {
+        return !delays.isEmpty();
+    }
+
+    public Optional<AutoMessages> getAutoMessagesForName(String name) {
+        return autoMessages.stream().filter(autoMessage -> name.equals(autoMessage.name)).findFirst();
+    }
+
+    public static final class AutoMessages {
+        static final String defaultName = "";
+        static final List<String> defaultMessages = List.of();
+        static final int defaultDelay = 1000;
+
+        String name = defaultName;
+        List<String> messages = defaultMessages;
+        int delay = defaultDelay;
+
+        public Iterator<String> getMessages() {
+            return messages.iterator();
+        }
+
+        public int getDelay() {
+            return delay;
+        }
+    }
+}

--- a/remappedSrc/autoreconnect/config/ModMenuIntegration.java
+++ b/remappedSrc/autoreconnect/config/ModMenuIntegration.java
@@ -1,0 +1,110 @@
+package autoreconnect.config;
+
+import autoreconnect.config.AutoReconnectConfig.AutoMessages;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import me.shedaniel.clothconfig2.gui.entries.IntegerListListEntry;
+import me.shedaniel.clothconfig2.gui.entries.MultiElementListEntry;
+import me.shedaniel.clothconfig2.gui.entries.NestedListListEntry;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.text.Text;
+
+import java.util.*;
+
+@SuppressWarnings("UnstableApiUsage")
+public class ModMenuIntegration implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return ModMenuIntegration::createConfigScreen;
+    }
+
+    private static Screen createConfigScreen(Screen parent) {
+        ConfigBuilder builder = ConfigBuilder.create()
+            .setParentScreen(parent)
+            .setTitle(Text.translatable("text.autoreconnect.config.title"));
+        ConfigEntryBuilder entryBuilder = builder.entryBuilder();
+        builder.getOrCreateCategory(Text.empty()) // text will be ignored since it's the only category
+            .addEntry(entryBuilder.startIntList(
+                    Text.translatable("text.autoreconnect.config.option.delays"),
+                    AutoReconnectConfig.getInstance().delays)
+                .setCreateNewInstance(list -> new IntegerListListEntry.IntegerListCell(AutoReconnectConfig.defaultDelay, list))
+                .setInsertInFront(false)
+                .setMin(1)
+                .setExpanded(true)
+                .setDefaultValue(AutoReconnectConfig.defaultDelays)
+                .setSaveConsumer(delays -> AutoReconnectConfig.getInstance().delays = delays)
+                .setTooltip(Text.translatable("text.autoreconnect.config.tooltip.option.delays"))
+                .build())
+            .addEntry(entryBuilder.startBooleanToggle(
+                    Text.translatable("text.autoreconnect.config.option.infinite"),
+                    AutoReconnectConfig.getInstance().infinite)
+                .setDefaultValue(AutoReconnectConfig.defaultInfinite)
+                .setTooltip(Text.translatable("text.autoreconnect.config.tooltip.option.infinite"))
+                .setSaveConsumer(infinite -> AutoReconnectConfig.getInstance().infinite = infinite)
+                .build())
+            .addEntry(new NestedListListEntry<AutoMessages, MultiElementListEntry<AutoMessages>>(
+                Text.translatable("text.autoreconnect.config.option.automessages"),
+                AutoReconnectConfig.getInstance().autoMessages,
+                true,
+                () -> Optional.of(new Text[]{Text.translatable("text.autoreconnect.config.tooltip.option.automessages")}),
+                list -> AutoReconnectConfig.getInstance().autoMessages = list,
+                () -> AutoReconnectConfig.defaultAutoMessages,
+                entryBuilder.getResetButtonKey(),
+                true,
+                false,
+                (autoMessages, listListEntry) -> createAutoMessagesEntry(entryBuilder, autoMessages != null ? autoMessages : new AutoMessages())));
+        return builder
+            .setSavingRunnable(AutoReconnectConfig.getInstance()::save)
+            .build();
+    }
+
+    private static MultiElementListEntry<AutoMessages> createAutoMessagesEntry(ConfigEntryBuilder entryBuilder, AutoMessages autoMessages) {
+        var tmp = new MultiElementListEntry<>(
+            Text.translatable("text.autoreconnect.config.option.automessages.instance"),
+            autoMessages,
+            Arrays.asList(
+                entryBuilder.startTextField(
+                        Text.translatable("text.autoreconnect.config.option.automessages.name"),
+                        autoMessages.name)
+                    .setErrorSupplier(ModMenuIntegration::emptyStringErrorSupplier)
+                    .setDefaultValue(AutoMessages.defaultName)
+                    .setTooltip(Text.translatable("text.autoreconnect.config.tooltip.option.automessages.name"))
+                    .setSaveConsumer(name -> autoMessages.name = name)
+                    .build(),
+                entryBuilder.startStrList(
+                        Text.translatable("text.autoreconnect.config.option.automessages.messages"),
+                        autoMessages.messages)
+                    .setErrorSupplier(ModMenuIntegration::emptyListErrorSupplier)
+                    .setCellErrorSupplier(ModMenuIntegration::emptyStringErrorSupplier)
+                    .setDefaultValue(AutoMessages.defaultMessages)
+                    .setInsertInFront(false)
+                    .setExpanded(true)
+                    .setTooltip(Text.translatable("text.autoreconnect.config.tooltip.option.automessages.messages"))
+                    .setSaveConsumer(messages -> autoMessages.messages = messages)
+                    .build(),
+                entryBuilder.startIntField(
+                        Text.translatable("text.autoreconnect.config.option.automessages.delay"),
+                        autoMessages.delay)
+                    .setDefaultValue(AutoMessages.defaultDelay)
+                    .setTooltip(Text.translatable("text.autoreconnect.config.tooltip.option.automessages.delay"))
+                    .setMin(1)
+                    .setSaveConsumer(delay -> autoMessages.delay = delay)
+                    .build()
+            ),
+            true);
+        tmp.setTooltipSupplier(() -> Optional.of(new Text[] {
+            Text.translatable("text.autoreconnect.config.tooltip.option.automessages.instance")
+        }));
+        return tmp;
+    }
+
+    private static Optional<Text> emptyListErrorSupplier(List<?> list) {
+        return list == null || list.isEmpty() ? Optional.of(Text.translatable("text.autoreconnect.config.error.empty_list")) : Optional.empty();
+    }
+
+    private static Optional<Text> emptyStringErrorSupplier(String str) {
+        return str == null || str.isEmpty() ? Optional.of(Text.translatable("text.autoreconnect.config.error.empty_string")) : Optional.empty();
+    }
+}

--- a/remappedSrc/autoreconnect/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/remappedSrc/autoreconnect/mixin/ClientPlayNetworkHandlerMixin.java
@@ -1,0 +1,17 @@
+package autoreconnect.mixin;
+
+import autoreconnect.AutoReconnect;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientPlayNetworkHandler.class)
+public class ClientPlayNetworkHandlerMixin {
+    @Inject(at = @At("TAIL"), method = "onGameJoin")
+    private void onGameJoin(GameJoinS2CPacket packet, CallbackInfo info) {
+        AutoReconnect.getInstance().onGameJoined();
+    }
+}

--- a/remappedSrc/autoreconnect/mixin/DisconnectedScreenMixin.java
+++ b/remappedSrc/autoreconnect/mixin/DisconnectedScreenMixin.java
@@ -1,0 +1,56 @@
+package autoreconnect.mixin;
+
+import autoreconnect.AutoReconnect;
+import net.minecraft.client.gui.screen.DisconnectedScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.gui.screen.world.SelectWorldScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(DisconnectedScreen.class)
+public class DisconnectedScreenMixin extends Screen {
+    @Shadow 
+    @Final 
+    @Mutable  
+    private Screen parent;
+
+    protected DisconnectedScreenMixin(Text title) {
+        super(title);
+    }
+
+    @Inject(at = @At("RETURN"), method = "<init>")
+    private void constructor(Screen parent, Text title, Text reason, CallbackInfo info) {
+        if (AutoReconnect.getInstance().isPlayingSingleplayer()) {
+            // make back button redirect to SelectWorldScreen instead of MultiPlayerScreen (Bug#45602)
+            this.parent = new SelectWorldScreen(new TitleScreen());
+        }
+    }
+
+    @Inject(at = @At("RETURN"), method = "init")
+    private void init(CallbackInfo info) {
+        if (AutoReconnect.getInstance().isPlayingSingleplayer()) {
+            // change back button text to "Back" instead of "Back to Server List" bcs of bug fix above
+            ((ButtonWidget) children().get(0)).setMessage(ScreenTexts.BACK);
+        }
+    }
+
+    // make this screen closable by pressing escape
+    @Inject(at = @At("RETURN"), method = "shouldCloseOnEsc", cancellable = true)
+    private void shouldCloseOnEsc(CallbackInfoReturnable<Boolean> info) {
+        info.setReturnValue(true);
+    }
+
+    // actually return to parent screen and not to the title screen
+    @Override
+    public void close() {
+        assert this.client != null;
+        this.client.setScreen(parent);
+    }
+}

--- a/remappedSrc/autoreconnect/mixin/DisconnectedScreensMixin.java
+++ b/remappedSrc/autoreconnect/mixin/DisconnectedScreensMixin.java
@@ -1,0 +1,100 @@
+package autoreconnect.mixin;
+
+import autoreconnect.AutoReconnect;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.DisconnectedScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.ButtonWidget.Builder;
+import net.minecraft.client.realms.gui.screen.DisconnectedRealmsScreen;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.concurrent.TimeUnit;
+
+@Mixin({DisconnectedScreen.class, DisconnectedRealmsScreen.class})
+public class DisconnectedScreensMixin extends Screen {
+    private ButtonWidget reconnectButton, cancelButton;
+    private boolean shouldAutoReconnect;
+
+    public DisconnectedScreensMixin(Text text) {
+        super(text);
+    }
+
+    
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    public void constructor(Screen parent, Text title, Text reason, CallbackInfo info) {
+
+        Builder reconnectBuilder = ButtonWidget.builder(Text.translatable("text.autoreconnect.disconnect.reconnect"), btn -> AutoReconnect.schedule(() -> MinecraftClient.getInstance().execute(this::manualReconnect), 100, TimeUnit.MILLISECONDS));
+        
+        reconnectButton = reconnectBuilder.dimensions(0, 0, 0, 20).build();
+
+        shouldAutoReconnect = AutoReconnect.getConfig().hasAttempts();
+        if (shouldAutoReconnect) {
+            AutoReconnect.getInstance().startCountdown(this::countdownCallback);
+        }
+    }
+
+    @Inject(method = "init", at = @At("TAIL"))
+    private void init(CallbackInfo info) {
+        Builder cancelBuilder = ButtonWidget.builder(Text.literal("✕").styled(s -> s.withColor(Formatting.RED)), btn -> cancelCountdown());
+        ButtonWidget backButton = (ButtonWidget) children().get(0);
+        // put reconnect (and cancel button) where back button is and push that down
+        reconnectButton.method_46421(backButton.getX());
+        reconnectButton.method_46419(backButton.getY());
+        if (shouldAutoReconnect) {
+            reconnectButton.setWidth(backButton.getWidth() - backButton.getHeight() - 4);
+
+            cancelButton = cancelBuilder.dimensions(backButton.getX() + backButton.getWidth() - backButton.getHeight(), backButton.getY(), 
+            backButton.getHeight(), backButton.getHeight()).build();
+
+            addDrawableChild(cancelButton);
+        } else {
+            reconnectButton.setWidth(backButton.getWidth());
+        }
+        addDrawableChild(reconnectButton);
+        backButton.method_46419(backButton.getY() + backButton.getHeight() + 4);
+    }
+
+    private void manualReconnect() {
+        AutoReconnect.getInstance().cancelAutoReconnect();
+        AutoReconnect.getInstance().reconnect();
+    }
+
+    private void cancelCountdown() {
+        AutoReconnect.getInstance().cancelAutoReconnect();
+        shouldAutoReconnect = false;
+        remove(cancelButton);
+        reconnectButton.active = true; // in case it was deactivated after running out of attempts
+        reconnectButton.setMessage(Text.translatable("text.autoreconnect.disconnect.reconnect"));
+        reconnectButton.setWidth(((ButtonWidget) children().get(0)).getWidth()); // reset to full width
+    }
+
+    private void countdownCallback(int seconds) {
+        if (seconds < 0) {
+            // indicates that we're out of attempts
+            reconnectButton.setMessage(Text.translatable("text.autoreconnect.disconnect.reconnect_failed")
+                .styled(s -> s.withColor(Formatting.RED)));
+            reconnectButton.active = false;
+        } else {
+            reconnectButton.setMessage(Text.translatable("text.autoreconnect.disconnect.reconnect_in", seconds)
+                .styled(s -> s.withColor(Formatting.GREEN)));
+        }
+    }
+
+    // cancel auto reconnect when pressing escape, higher priority than exiting the screen
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (keyCode == 256 && shouldAutoReconnect) {
+            cancelCountdown();
+            return true;
+        } else {
+            return super.keyPressed(keyCode, scanCode, modifiers);
+        }
+    }
+}

--- a/remappedSrc/autoreconnect/mixin/MinecraftClientMixin.java
+++ b/remappedSrc/autoreconnect/mixin/MinecraftClientMixin.java
@@ -1,0 +1,33 @@
+package autoreconnect.mixin;
+
+import autoreconnect.AutoReconnect;
+import autoreconnect.reconnect.SingleplayerReconnectStrategy;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.*;
+import net.minecraft.resource.ResourcePackManager;
+import net.minecraft.server.SaveLoader;
+import net.minecraft.world.level.storage.LevelStorage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static org.objectweb.asm.Opcodes.PUTFIELD;
+
+@Mixin(MinecraftClient.class)
+public class MinecraftClientMixin {
+    @Shadow 
+    private Screen currentScreen;
+
+    @Inject(method = "startIntegratedServer", at = @At("HEAD"))
+    private void startIntegratedServer(String levelName, LevelStorage.Session session, ResourcePackManager dataPackManager, SaveLoader saveLoader, boolean newWorld, CallbackInfo info) {
+        AutoReconnect.getInstance().setReconnectHandler(new SingleplayerReconnectStrategy(levelName));
+    }
+
+    @Inject(method = "setScreen", at = @At(value = "FIELD", opcode = PUTFIELD,
+        target = "Lnet/minecraft/client/MinecraftClient;currentScreen:Lnet/minecraft/client/gui/screen/Screen;"))
+    private void setScreen(Screen newScreen, CallbackInfo info) {
+        AutoReconnect.getInstance().onScreenChanged(currentScreen, newScreen);
+    }
+}

--- a/remappedSrc/autoreconnect/mixin/MultiplayerScreenMixin.java
+++ b/remappedSrc/autoreconnect/mixin/MultiplayerScreenMixin.java
@@ -1,0 +1,18 @@
+package autoreconnect.mixin;
+
+import autoreconnect.AutoReconnect;
+import autoreconnect.reconnect.MultiplayerReconnectStrategy;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.network.ServerInfo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MultiplayerScreen.class)
+public class MultiplayerScreenMixin {
+    @Inject(at = @At("TAIL"), method = "connect(Lnet/minecraft/client/network/ServerInfo;)V")
+    private void connect(ServerInfo entry, CallbackInfo info) {
+        AutoReconnect.getInstance().setReconnectHandler(new MultiplayerReconnectStrategy(entry));
+    }
+}

--- a/remappedSrc/autoreconnect/mixin/RealmsConnectionMixin.java
+++ b/remappedSrc/autoreconnect/mixin/RealmsConnectionMixin.java
@@ -1,0 +1,19 @@
+package autoreconnect.mixin;
+
+import autoreconnect.AutoReconnect;
+import autoreconnect.reconnect.RealmsReconnectStrategy;
+import net.minecraft.client.network.ServerAddress;
+import net.minecraft.client.realms.RealmsConnection;
+import net.minecraft.client.realms.dto.RealmsServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RealmsConnection.class)
+public class RealmsConnectionMixin {
+    @Inject(at = @At("HEAD"), method = "connect")
+    private void connect(RealmsServer server, ServerAddress address, CallbackInfo info) {
+        AutoReconnect.getInstance().setReconnectHandler(new RealmsReconnectStrategy(server));
+    }
+}

--- a/remappedSrc/autoreconnect/reconnect/MultiplayerReconnectStrategy.java
+++ b/remappedSrc/autoreconnect/reconnect/MultiplayerReconnectStrategy.java
@@ -1,0 +1,30 @@
+package autoreconnect.reconnect;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConnectScreen;
+import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.network.ServerAddress;
+import net.minecraft.client.network.ServerInfo;
+
+public class MultiplayerReconnectStrategy extends ReconnectStrategy {
+    private final ServerInfo serverInfo;
+
+    public MultiplayerReconnectStrategy(ServerInfo serverInfo) {
+        this.serverInfo = serverInfo;
+    }
+
+    @Override
+    public String getName() {
+        return serverInfo.name;
+    }
+
+    @Override
+    public void reconnect() {
+        ConnectScreen.connect(
+            new MultiplayerScreen(new TitleScreen()),
+            MinecraftClient.getInstance(),
+            ServerAddress.parse(serverInfo.address),
+            serverInfo);
+    }
+}

--- a/remappedSrc/autoreconnect/reconnect/RealmsReconnectStrategy.java
+++ b/remappedSrc/autoreconnect/reconnect/RealmsReconnectStrategy.java
@@ -1,0 +1,26 @@
+package autoreconnect.reconnect;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.realms.dto.RealmsServer;
+import net.minecraft.client.realms.gui.screen.RealmsMainScreen;
+
+public class RealmsReconnectStrategy extends ReconnectStrategy {
+    private final RealmsServer realmsServer;
+
+    public RealmsReconnectStrategy(RealmsServer realmsServer) {
+        this.realmsServer = realmsServer;
+    }
+
+    @Override
+    public String getName() {
+        return realmsServer.getName();
+    }
+
+    @Override
+    public void reconnect() {
+        RealmsMainScreen realmsMainScreen = new RealmsMainScreen(new TitleScreen());
+        realmsMainScreen.init(MinecraftClient.getInstance(), 0, 0); // init but don't set screen!
+        realmsMainScreen.play(realmsServer, realmsMainScreen);
+    }
+}

--- a/remappedSrc/autoreconnect/reconnect/ReconnectStrategy.java
+++ b/remappedSrc/autoreconnect/reconnect/ReconnectStrategy.java
@@ -1,0 +1,24 @@
+package autoreconnect.reconnect;
+
+public abstract class ReconnectStrategy {
+    private int attempt = -1;
+
+    // package-private constructor
+    ReconnectStrategy() { }
+
+    public abstract void reconnect();
+
+    public abstract String getName();
+
+    public final int nextAttempt() {
+        return ++attempt;
+    }
+
+    public final boolean isAttempting() {
+        return attempt >= 0;
+    }
+
+    public final void resetAttempts() {
+        attempt = -1;
+    }
+}

--- a/remappedSrc/autoreconnect/reconnect/SingleplayerReconnectStrategy.java
+++ b/remappedSrc/autoreconnect/reconnect/SingleplayerReconnectStrategy.java
@@ -1,0 +1,31 @@
+package autoreconnect.reconnect;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.MessageScreen;
+import net.minecraft.client.gui.screen.world.WorldListWidget;
+import net.minecraft.text.Text;
+
+public class SingleplayerReconnectStrategy extends ReconnectStrategy {
+    private final String worldName;
+
+    public SingleplayerReconnectStrategy(String worldName) {
+        this.worldName = worldName;
+    }
+
+    @Override
+    public String getName() {
+        return worldName;
+    }
+
+    /**
+     * @see WorldListWidget.WorldEntry#start()
+     * @see WorldListWidget.WorldEntry#openReadingWorldScreen()
+     */
+    @Override
+    public void reconnect() {
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (!client.getLevelStorage().levelExists(getName())) return;
+        client.setScreenAndRender(new MessageScreen(Text.translatable("selectWorld.data_read")));
+        client.createIntegratedServerLoader().start(client.currentScreen, getName());
+    }
+}

--- a/src/main/java/autoreconnect/AutoReconnect.java
+++ b/src/main/java/autoreconnect/AutoReconnect.java
@@ -18,6 +18,8 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntConsumer;
 
+ // TODO take a look at https://github.com/Bstn1802/AutoReconnect/issues/42
+
 public class AutoReconnect implements ClientModInitializer {
     private static final ScheduledThreadPoolExecutor EXECUTOR_SERVICE = new ScheduledThreadPoolExecutor(1);
     private static AutoReconnect instance;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,11 +29,11 @@
   "depends": {
     "java": ">=17",
     "fabric-api": "*",
-    "fabricloader": ">=0.11.3",
-    "minecraft": ">=1.18.1",
-    "cloth-config": ">=6.0.0"
+    "fabricloader": ">=0.14.19",
+    "minecraft": ">=1.19.4",
+    "cloth-config": ">=10.0.96"
   },
   "suggests": {
-    "modmenu": ">=3.0.0"
+    "modmenu": ">=6.1.0-rc.4"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "id": "${id}",
-  "version": "${version}",
-  "name": "${name}",
+  "id": "autoreconnect",
+  "version": "3.0.0-beta",
+  "name": "AutoReconnect",
   "description": "This mod will automatically try to reconnect you back to a server if you got disconnected.\nBy default, it will make 4 attempts after 3, 10, 30 and 60 seconds.",
   "authors": [
     "Bstn1802"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "sources": "https://github.com/Bstn1802/AutoReconnect",
     "issues": "https://github.com/Bstn1802/AutoReconnect/issues"
   },
-  "license": "CC0-1.0",
+  "license": "GPL-3.0",
   "icon": "assets/icon16.png",
   "environment": "client",
   "entrypoints": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,10 +28,10 @@
   ],
   "depends": {
     "java": ">=17",
-    "fabric": "*",
+    "fabric-api": "*",
     "fabricloader": ">=0.11.3",
     "minecraft": ">=1.18.1",
-    "cloth-config2": ">=6.0.0"
+    "cloth-config": ">=6.0.0"
   },
   "suggests": {
     "modmenu": ">=3.0.0"


### PR DESCRIPTION
This PR updates the mod to 1.19.4

I was approached by a user on Discord named dreamcatcher#8788 to update the mod to 1.19.4, which I did
There aren't many changes, just migrated the mappings and updated the dependencies
It worked fine on my end, and I gave a build to dreamcatcher to test, they got back to me saying that everything worked fine.

I also specifically asked them to test if the issue mentioned by @Bstn1802 in https://github.com/Bstn1802/AutoReconnect/issues/38 occurs, and they told me that it does not, so the mod can probably be released to CurseForge without any changes.

I also updated the license in the fabric.mod.json to GPL-3.0, to match the license on the GH repo
On that note, you should probably take a look at https://github.com/Bstn1802/AutoReconnect/issues/42, as the GPL license is not advisable for Minecraft mods.

The only change that you might want to revert is https://github.com/Bstn1802/AutoReconnect/commit/c389e6295ef321b3d21520c9c6da43d91901bfe6, which I made because, for some reason, the variables were not resolving when I launched the game, and I got an error saying that the variables were invalid.