### PR TITLE
1.20.1 & fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,18 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.20
-yarn_mappings=1.20+build.1
-loader_version=0.14.21
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.10
+loader_version= 0.14.21
 
 # Mod Properties
 mod_id = autoreconnect
 mod_name = AutoReconnect
-mod_version = 2.2.0
+mod_version = 2.2.1
 archives_base_name = autoreconnect
 
 # Dependencies
-fabric_version=0.83.0+1.20
+#Fabric api
+fabric_version=0.86.0+1.20.1
 modmenu_version=7.0.0
 cloth_config_version=11.0.99

--- a/src/main/java/autoreconnect/config/AutoReconnectConfig.java
+++ b/src/main/java/autoreconnect/config/AutoReconnectConfig.java
@@ -6,10 +6,8 @@ import com.google.gson.JsonSyntaxException;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.loader.api.FabricLoader;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/autoreconnect/config/AutoReconnectConfig.java
+++ b/src/main/java/autoreconnect/config/AutoReconnectConfig.java
@@ -6,8 +6,10 @@ import com.google.gson.JsonSyntaxException;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.loader.api.FabricLoader;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -21,10 +23,12 @@ public final class AutoReconnectConfig {
     static final List<Integer> defaultDelays = List.of(3, 10, 30, 60);
     static final int defaultDelay = 10;
     static final boolean defaultInfinite = false;
+    public static final String defaultServerAddress = "localhost";
     static final List<AutoMessages> defaultAutoMessages = List.of();
 
     List<Integer> delays = defaultDelays;
     boolean infinite = defaultInfinite;
+    public String serverAddress = defaultServerAddress;
     List<AutoMessages> autoMessages = defaultAutoMessages;
 
     private AutoReconnectConfig() { }
@@ -35,13 +39,12 @@ public final class AutoReconnectConfig {
 
     public static void load() {
         try {
-            instance = GSON.fromJson(
-                Files.readString(FabricLoader.getInstance().getConfigDir().resolve(FILE_NAME)),
-                AutoReconnectConfig.class);
+            instance = GSON.fromJson(Files.readString(FabricLoader.getInstance().getConfigDir().resolve(FILE_NAME)), AutoReconnectConfig.class);
             instance.validate();
         } catch (IOException | JsonSyntaxException ex) {
             LogUtils.getLogger().warn("AutoReconnect could not load the config", ex);
             instance = new AutoReconnectConfig();
+            instance.save();
         }
     }
 

--- a/src/main/java/autoreconnect/config/ModMenuIntegration.java
+++ b/src/main/java/autoreconnect/config/ModMenuIntegration.java
@@ -44,6 +44,13 @@ public class ModMenuIntegration implements ModMenuApi {
                 .setTooltip(Text.translatable("text.autoreconnect.config.tooltip.option.infinite"))
                 .setSaveConsumer(infinite -> AutoReconnectConfig.getInstance().infinite = infinite)
                 .build())
+            .addEntry(entryBuilder.startTextField(
+                    Text.translatable("text.autoreconnect.config.tooltip.option.serveraddress"),
+                    AutoReconnectConfig.getInstance().serverAddress)
+                 .setDefaultValue(AutoReconnectConfig.defaultServerAddress)
+                 .setTooltip(Text.translatable("text.autoreconnect.config.tooltip.option.serveraddress"))
+                 .setSaveConsumer(serverAddress -> AutoReconnectConfig.getInstance().serverAddress = serverAddress)
+                 .build())
             .addEntry(new NestedListListEntry<AutoMessages, MultiElementListEntry<AutoMessages>>(
                 Text.translatable("text.autoreconnect.config.option.automessages"),
                 AutoReconnectConfig.getInstance().autoMessages,

--- a/src/main/java/autoreconnect/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/autoreconnect/mixin/ClientPlayNetworkHandlerMixin.java
@@ -4,7 +4,6 @@ import autoreconnect.AutoReconnect;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ServerInfo;
 import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
-import org.apache.logging.log4j.core.jmx.Server;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;

--- a/src/main/java/autoreconnect/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/autoreconnect/mixin/ClientPlayNetworkHandlerMixin.java
@@ -2,16 +2,24 @@ package autoreconnect.mixin;
 
 import autoreconnect.AutoReconnect;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.network.ServerInfo;
 import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
+import org.apache.logging.log4j.core.jmx.Server;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPlayNetworkHandler.class)
 public class ClientPlayNetworkHandlerMixin {
+    @Shadow
+    @Final
+    private ServerInfo serverInfo;
+
     @Inject(at = @At("TAIL"), method = "onGameJoin")
     private void onGameJoin(GameJoinS2CPacket packet, CallbackInfo info) {
-        AutoReconnect.getInstance().onGameJoined();
+        AutoReconnect.getInstance().onGameJoined(serverInfo);
     }
 }

--- a/src/main/resources/assets/autoreconnect/lang/en_us.json
+++ b/src/main/resources/assets/autoreconnect/lang/en_us.json
@@ -15,6 +15,7 @@
 
   "text.autoreconnect.config.tooltip.option.delays": "Delays between attempts in seconds",
   "text.autoreconnect.config.tooltip.option.infinite": "Whether to repeat reconnecting with the last configured delay",
+  "text.autoreconnect.config.tooltip.option.serveraddress": "Server address to reconnect to",
   "text.autoreconnect.config.tooltip.option.automessages": "Messages to send after a successful automatic reconnect",
   "text.autoreconnect.config.tooltip.option.automessages.instance": "Single AutoMessages object for a specific world, server or realm",
   "text.autoreconnect.config.tooltip.option.automessages.name": "Name of the singleplayer world, server entry or realm",


### PR DESCRIPTION
Hello!

When using MultiMC or adding the `--server` or `--quickPlayMultiplayer` flags to the client, you won't ever see or interact with the client screens; for that reason, the available mixins for singleplayer, multiplayer, and realms won't register the appropriate reconnect strategy. 

To let people use the mod when using MultiMC with auto-connect (or the flags), I handled the case where the strategy is null. Also, I added a config option for those who prefer to set the server to reconnect manually. 

Changes:
1) Added a config option to allow the user set the server address where they should reconnect
2) Let the mod save the default config file if it does not exist when starting up.
3) Modified the `ClientPlayNetworkHandlerMixin` to pass the `ServerInfo` to the `onGameJoined` method and manually handle the case where the `reconnectStrategy` field is null, which would be most likely this case 99% of the time.

Related case @HyCore: #49 