### PR TITLE
Kill game client if invalid sesstion

### DIFF
--- a/src/main/java/autoreconnect/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/autoreconnect/mixin/DisconnectedScreenMixin.java
@@ -5,12 +5,16 @@ import net.minecraft.client.gui.screen.DisconnectedScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.screen.world.SelectWorldScreen;
+import net.minecraft.client.MinecraftClient;
+import com.mojang.logging.LogUtils;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+
 
 @Mixin(DisconnectedScreen.class)
 public class DisconnectedScreenMixin extends Screen {
@@ -25,6 +29,13 @@ public class DisconnectedScreenMixin extends Screen {
 
     @Inject(at = @At("RETURN"), method = "<init>(Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/text/Text;Lnet/minecraft/text/Text;Lnet/minecraft/text/Text;)V")
     private void constructor(Screen parent, Text title, Text reason, Text buttonLabel, CallbackInfo info) {
+        // close game
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client != null && reason != null && reason.getString().contains("Invalid session")) {
+            LogUtils.getLogger().error("AutoReconnect closing game because of expired token...");
+            client.stop();
+        }
+
         if (AutoReconnect.getInstance().isPlayingSingleplayer()) {
             // make back button redirect to SelectWorldScreen instead of MultiPlayerScreen (https://bugs.mojang.com/browse/MC-45602)
             this.parent = new SelectWorldScreen(new TitleScreen());


### PR DESCRIPTION
Hey @Bstn1802 ,

https://github.com/Bstn1802/AutoReconnect/issues/57

This is my first ever modification on the client side of minecraft.  I have an issue where my gameclient sometimes gets the tokens expired after runing for a while...

I added a few lines here to close the game.  The game then will reopen because I have the https://github.com/mindstorm38/portablemc laucnher running on a  while true.

Let me knw what you think and if this is something that could be added to the config section. 

If you like it then I will continue to work on it.

<3 Hoobs